### PR TITLE
fix: data export with .h5 format

### DIFF
--- a/docs/source/getting_started/export_data.rst
+++ b/docs/source/getting_started/export_data.rst
@@ -1,0 +1,153 @@
+.. _export_data:
+
+Export data
+=================
+
+The data structure that is exported is a HDF5 file, and is structured as follows:
+
+.. code-block::
+
+   frame_001/
+   ├── cells/
+   │   ├── cell_001/
+   │   │   ├── name (attribute)
+   │   │   ├── loc (dataset)
+   │   │   ├── volume (float)
+   │   │   ├── pressure (float)
+   │   │   ├── gene_x_conc (float)
+   │   │   ├── gene_y_conc (float)
+   │   │   ├── ...
+   │   │   ├── mol_A_conc (float)
+   │   │   ├── mol_B_conc (float)
+   │   │   └── ...
+   │   └── cell_002/
+   │       └── ...
+   └── concentration_grid/
+      ├── mol_A/
+      │   ├── dimensions (dataset)
+      │   └── values (dataset)
+      └── mol_B/
+         ├── dimensions (dataset)
+         └── values (dataset)
+   frame_002/
+   ├── cells/
+   │   └── ...
+   
+
+1. Use goo.visualization module to plot simulation data
+---------------------------------------------------------
+
+Examples of simulation script can be found in the `/simulations/` folder, located `here <https://github.com/megasonlab/Goo/tree/main/simulations>`__. 
+Goo extends Blender towards agent-based simulations of cell mechanics, molecular reactions and gene regulatory networks.
+With Goo, you can create custom scripts to simulate various cellular phenomena by specifying initial conditions and parameters.
+
+Running scripts
+~~~~~~~~~~~~~~~~~~~
+
+Goo scripts typically get ran from Blender's scripting tab, though they can be ran from Visual Studio Code directly using the `developer's extension <https://marketplace.visualstudio.com/items?itemName=JacquesLucke.blender-development>`__ developed by Jacques Lucke. 
+
+Initialization
+~~~~~~~~~~~~~~~~~~~
+All simulation scripts should begin with `goo.reset_modules()` and `reset_scene()` to ensure a clean starting environment. 
+The latter removes all objects from the Blender scene and resets simulation parameters to their default values.
+
+.. code-block:: python
+
+   import goo
+
+   goo.reset_modules()
+   goo.reset_scene()
+
+Next, define cell types along with their physical properties, such as surface stiffness and adhesion strength. 
+Stiffer cells are less deformable, while higher adhesion strength increases deformation from their initial spherical shape. 
+The ratio of stiffness to adhesion strength influences resulting cell patterns (Garner, Tsai, and Megason, 2022). 
+Most parameters in Goo are dimensionless.
+
+Defining cell types
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   cellsA = goo.CellType("A", target_volume=70, pattern="simple")
+   cellsB = goo.CellType("B", target_volume=70, pattern="simple")
+   cellsC = goo.CellType("C", target_volume=70, pattern="simple")
+
+   cellsA.homo_adhesion_strength = 1
+   cellsA.stiffness = 1  # ratio = 1
+   cellsB.homo_adhesion_strength = 500
+   cellsB.stiffness = 1  # ratio = 500
+   cellsC.homo_adhesion_strength = 2000
+   cellsC.stiffness = 1  # ratio = 2000
+
+
+Creating cells
+~~~~~~~~~~~~~~~~~~~
+
+Populate cell types with individual cells using `create_cell()`. Specify their initial location, size, shape, and optional material color for visualization.
+
+.. code-block:: python
+
+   cellsA.create_cell("A1", (-20, +1.75, 0), color=(1, 1, 0), size=1.6)
+   cellsA.create_cell("A2", (-20, -1.75, 0), color=(1, 1, 0), size=1.6)
+
+   cellsB.create_cell("B1", (0, +1.75, 0), color=(0, 1, 1), size=1.6)
+   cellsB.create_cell("B2", (0, -1.75, 0), color=(0, 1, 1), size=1.6)
+
+   cellsC.create_cell("C1", (20, +1.75, 0), color=(1, 0, 1), size=1.6)
+   cellsC.create_cell("C2", (20, -1.75, 0), color=(1, 0, 1), size=1.6)
+
+
+Setting up the simulator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To introduce cell behaviors like adhesion, motility and division, use the simulator. It handles the simmulation of cell physics and solving sets of ODEs over time for genetic circuitry. 
+Define total simulation time, time step (`physics_dt` for mechanics, `molecular_dt` for reactions), and which cell types to include in the simulation.
+If not included, objects will remain static.
+
+.. note::
+
+   Goo uses two simulation engines: one for cell mechanics on meshes and one for discrete molecular reactions on KD-trees and gene regulatory circuitry for each cell. 
+   Molecular processes happen at faster time scale than cell mechanics; therefore `physics_dt` typically needs be set at least 10 times larger than `molecular_dt`.
+
+The `setup_world()` function always needs be defined, and it's best practice to always set a random seed for reproducibility. It sets some general parameters (e.g. turning gravity off), units and length scales. 
+
+.. code-block:: python
+
+   sim = goo.Simulator([cellsA, cellsB, cellsC], time=180, physics_dt=1)
+   sim.setup_world(seed=2024)
+
+
+Appending handlers to the simulator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Handlers modularly define cell behavior. They execute functions sequentially at every time step. They can take some parameters as arguments to control e.g. the rate of division based on cell volume. 
+Add handlers to the simulator to control these aspects. For example: these lines model cell growth, homotypic adhesion, volume-based division (target volume of 50 :math:`\mu m^3` with a std.dev. of 1) and gaussian random motion. 
+
+.. code-block:: python
+
+   sim.add_handlers(
+      [
+         goo.GrowthPIDHandler(),                                           # in um3
+         goo.RecenterHandler(),
+         goo.SizeDivisionHandler(goo.BisectDivisionLogic, mu=60, sigma=1), # in um3
+         goo.RandomMotionHandler(goo.ForceDist.GAUSSIAN, strength=500)
+      ]
+   )
+
+.. note::
+   
+   The full list of handlers–cell behaviors the library currently supports–can be found in the codebase documentation. 
+
+When put all together, this is the script outlined:
+
+.. admonition:: Goo script
+   :class: dropdown
+
+   .. literalinclude:: ../examples/1_growing_doublets.py
+      :language: python
+
+Running this script in Blender produces the following simulation:
+
+.. video:: ../examples/1_growing_doublets.mp4
+   :width: 740
+   :loop:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,14 @@ blender45 = [
     "fake-bpy-module==20240524"
 ]
 
+# Visualization tools
+viz = [
+    "streamlit>=1.32.0",
+    "numpy>=1.24.0",
+    "pandas>=2.0.0",
+    "matplotlib>=3.7.0",
+]
+
 # Development tools
 dev = [
     "pytest==8.3.4",

--- a/scratch/requirements.txt
+++ b/scratch/requirements.txt
@@ -1,8 +1,5 @@
-tifffile>=2023.0.0
+streamlit>=1.32.0
 numpy>=1.24.0
+pandas>=2.0.0
 matplotlib>=3.7.0
-imageio>=2.31.0
-imageio-ffmpeg>=0.4.8
-scikit-image>=0.21.0
-tqdm>=4.65.0
-Pillow>=10.0.0 
+h5py>=3.8.0 

--- a/simulations/10_extracellular_sensing.py
+++ b/simulations/10_extracellular_sensing.py
@@ -9,6 +9,7 @@ goo.reset_scene()
 # Defining cells
 celltype = goo.CellType("cellA", target_volume=70, pattern="simple")
 celltype.homo_adhesion_strength = 500
+celltype.motion_strength = 100
 cell = celltype.create_cell(name="cell", loc=(0, 0, 0), color=(0, 1, 1))
 cell.stiffness = 5
 

--- a/simulations/6_export_data.py
+++ b/simulations/6_export_data.py
@@ -1,26 +1,80 @@
+# import goo
+
+# goo.reset_modules()
+# goo.reset_scene()
+
+# # Defining cells
+# x = goo.Gene("x")
+# y = goo.Gene("y")
+# z = goo.Gene("z")
+
+# celltype = goo.CellType("cellA", pattern="simple", target_volume=70)
+# celltype.homo_adhesion_strength = 500
+# cell = celltype.create_cell(name="cell1", loc=(0, 0, 0), color=(0, 0, 0))
+# cell.stiffness = 5
+
+# network1 = goo.GeneRegulatoryNetwork()
+# network1.load_circuits(
+#     goo.DegFirstOrder(x, 0.1),
+#     goo.DegFirstOrder(y, 0.1),
+#     goo.DegFirstOrder(z, 0.1),
+#     goo.ProdRepression(y, x, kcat=0.4, n=3),
+#     goo.ProdRepression(z, y, kcat=0.4, n=3),
+#     goo.ProdRepression(x, z, kcat=0.4, n=3),
+# )
+# cell.grn = network1
+# cell.gene_concs = {x: 2, y: 0.1, z: 0.1}
+
+# sim = goo.Simulator(celltypes=[celltype], time=200, physics_dt=1)
+# sim.setup_world(seed=2025)
+# sim.add_handlers(
+#     [
+#         goo.GrowthPIDHandler(),
+#         goo.SizeDivisionHandler(goo.BisectDivisionLogic, mu=60, sigma=2),
+#         goo.RecenterHandler(),
+#         goo.RemeshHandler(),
+#         goo.NetworkHandler(),
+#         goo.ColorizeHandler(goo.Colorizer.GENE, x, range=(1, 2)),
+#                 goo.DataExporter(
+#             path="/Users/antoine/Harvard/MegasonLab/GPU_backup/AntoineRuzette/goo/data/out"
+#         ),
+#     ]
+# )
+
+from importlib import reload
+
 import goo
 
+
+reload(goo)
 goo.reset_modules()
 goo.reset_scene()
 
 # Defining cells
-celltype = goo.CellType("cellA", target_volume=50, pattern="simple")
-celltype.homo_adhesion_strength = 1000
-cell1 = celltype.create_cell(name="cell", loc=(0, 0, 0), color=(0, 1, 1))
-cell1.stiffness = 2
-cell1.pressure = 5
+celltype = goo.CellType("cellA", target_volume=70, pattern="simple")
+celltype.homo_adhesion_strength = 500
+celltype.motion_strength = 100
+cell = celltype.create_cell(name="cell", loc=(0, 0, 0), color=(0, 1, 1))
+cell.stiffness = 5
 
-sim = goo.Simulator(celltypes=[celltype], time=500, physics_dt=1)
+mol = goo.Molecule("mol", conc=5, D=0, gradient="linear")
+diffsys = goo.DiffusionSystem(molecules=[mol])
+cell.diffsys = diffsys
+cell.link_molecule_to_property(mol, "motion_direction")
+
+sim = goo.Simulator(celltypes=[celltype], time=500, physics_dt=1, diffsystems=[diffsys])
 sim.setup_world()
 sim.add_handlers(
     [
         goo.GrowthPIDHandler(),
+#        goo.SizeDivisionHandler(goo.BisectDivisionLogic, mu=60, sigma=2),
         goo.RecenterHandler(),
-        goo.RandomMotionHandler(distribution=goo.ForceDist.UNIFORM, strength=250),
+#        goo.RemeshHandler(),
+        goo.ColorizeHandler(goo.Colorizer.RANDOM),
+        goo.MolecularHandler(),
+        goo.ConcentrationVisualizationHandler(spacing=1),
         goo.DataExporter(
-            path="tmp/out.json",
-            options=goo.DataFlag.CELL_CONCENTRATIONS
-            | goo.DataFlag.MOTION_PATH,  # or ALL flag
+            path="/Users/antoine/Harvard/MegasonLab/GPU_backup/AntoineRuzette/goo/data/out"
         ),
     ]
 )

--- a/src/goo/__init__.py
+++ b/src/goo/__init__.py
@@ -7,7 +7,6 @@ from .handler import *
 from .molecule import *
 from .boundary import *
 from .gene import *
-
 __version__ = "1.0.0"
 __author__ = "Antoine A. Ruzette, Charles Dai, Sean Megason"
 __credits__ = "Harvard Medical School"

--- a/src/goo/cell.py
+++ b/src/goo/cell.py
@@ -624,16 +624,12 @@ class Cell(BlenderObject):
         return self.obj.__contains__(k)
 
     # ===== Sensing and secretion =====
-
     @property
     def molecule_concs(self):
         """Get the concentrations of the molecules around the cell radius."""
-        return self.diffsys.get_concentrations(self.COM(), self.radius())
-
-    # @molecule_concs.setter
-    # def secrete_molecule_concs(self, molecule_concs):
-    #     self["molecules"] = {str(k): v for k, v in molecule_concs.items()}
-    #     self.diffsys.molecule_concs = molecule_concs
+        if not self.diffsys:
+            return {}
+        return {mol: self.diffsys.get_total_ball_concentrations(mol, self.COM(), self.radius()) for mol in self.diffsys.molecules}
 
     def link_molecule_to_property(self, molecule: Molecule, property):
         """Link molecule to property, so that changes in the extracellular
@@ -756,7 +752,7 @@ def create_scalar_updater(
         case _:
             raise NotImplementedError()
 
-    return PropertyUpdater(gene_getter, transformer, setter)
+    return PropertyUpdater(metabolite_getter, transformer, setter)
 
 
 def create_direction_updater(

--- a/src/goo/division.py
+++ b/src/goo/division.py
@@ -154,6 +154,10 @@ class BooleanDivisionLogic(DivisionLogic):
         daughter = Cell(bpy.context.selected_objects[0])
         daughter.obj.select_set(False)
 
+        # Copy mother's pressure to daughter
+        if mother.cloth_mod and daughter.cloth_mod:
+            daughter.pressure = mother.pressure
+
         daughter.name = mother.name + ".1"
         mother.name = mother.name + ".0"
 


### PR DESCRIPTION
Improved the data export to follow a more structured data structure, with .h5 support for fast I/O of large 3D arrays of concentrations of the grid. 

```
   frame_001/
   ├── cells/
   │   ├── cell_001/
   │   │   ├── name (attribute)
   │   │   ├── loc (dataset)
   │   │   ├── volume (float)
   │   │   ├── pressure (float)
   │   │   ├── gene_x_conc (float)
   │   │   ├── gene_y_conc (float)
   │   │   ├── ...
   │   │   ├── mol_A_conc (float)
   │   │   ├── mol_B_conc (float)
   │   │   └── ...
   │   └── cell_002/
   │       └── ...
   └── concentration_grid/
      ├── mol_A/
      │   ├── dimensions (dataset)
      │   └── values (dataset)
      └── mol_B/
         ├── dimensions (dataset)
         └── values (dataset)
   frame_002/
   ├── cells/
   │   └── ...

```